### PR TITLE
Link to SubmittingPatches at git-scm.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 		<div class="block">
 			<p>
 				Unlike most open source projects, Git itself does not accept code contributions via Pull Requests.
-				Instead, patches are <a href="https://github.com/git/git/blob/master/Documentation/SubmittingPatches">submitted to the Git mailing list</a> for review and will be applied manually by the Git maintainer.
+				Instead, patches are <a href="https://git-scm.com/docs/SubmittingPatches">submitted to the Git mailing list</a> for review and will be applied manually by the Git maintainer.
 			</p><p>
 				Apart from lacking the convenience of a web interface, this process also puts considerable demands on the code contributions: the mails are expected to be plain text only (no HTML!), for example, and the diffs embedded in the mails must apply cleanly (no whitespace changes!), among other things.
 			</p><p>
@@ -56,7 +56,7 @@
 				And you already pushed it to your own fork?
 				Good, now is the time to direct your web browser to <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> and to open a Pull Request.
 				Please make sure to use a descriptive Pull Request title and description; GitGitGadget will use these as the cover letter.
-				You will also want to read <a href="https://github.com/git/git/blob/master/Documentation/SubmittingPatches">Git's guidelines</a> to make sure that your contributions are in the expected form.
+				You will also want to read <a href="https://git-scm.com/docs/SubmittingPatches">Git's guidelines</a> to make sure that your contributions are in the expected form.
 			</p><p>
 				The first time you use GitGitGadget, you need to be added to the list of users with permission to use GitGitGadget (this is a <i>very</i> simple anti-spam measure).
 				Any user who is already on that list can do that, by adding a comment to that Pull Request that says <tt>/allow &lt;username&gt;</name></tt> (with your GitHub login name).


### PR DESCRIPTION
Since the SubmittingPatches page is nicely formatted on the Git website, 
it makes for a nicer reading experience, so let's link to that instead of the raw file on GitHub.