### PR TITLE
Mention using GGG on github.com/git/git

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,8 @@
 				Good, now is the time to direct your web browser to <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> (or to <a href="https://github.com/gitgitgadget/git">https://github.com/git/git</a> ) and to open a Pull Request.
 				Please make sure to use a descriptive Pull Request title and description; GitGitGadget will use these as the subject and body of the cover letter (check out the <a href="https://git-scm.com/docs/MyFirstContribution">MyFirstContribution</a> tutorial if you are not familiar with this terminology).
 				You can CC potential reviewers by adding a footer to the PR description with the following syntax:
-				<pre>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</pre>
+			</p><p>
+				<code>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</code>
 			</p><p>
 				You will also want to read <a href="https://git-scm.com/docs/SubmittingPatches">Git's contribution guidelines</a> to make sure that your contributions are in the expected form, as well as the project's <a href="https://github.com/git/git/blob/master/Documentation/CodingGuidelines">coding guidelines</a>.
 				You might also want to read the <a href="https://git-scm.com/docs/gitworkflows">gitworkflows</a> manual page to understand how your contributions will be integrated in Git's repository, as well as <a href="https://github.com/git/git/blob/todo/MaintNotes">this note from Git's maintainer</a>.

--- a/index.html
+++ b/index.html
@@ -27,6 +27,51 @@
 			tiny {
 				font-size: 70%;
 			}
+			.tg {
+				border-collapse: collapse;
+				border-spacing: 0;
+				margin: 0px auto;
+			}
+			.tg td {
+				padding: 10px 5px;
+				border-style: solid;
+				border-width: 1px;
+				overflow: hidden;
+				word-break: normal;
+				border-color: black;
+			}
+			.tg th {
+				font-weight: bold;
+				padding: 10px 5px;
+				border-style: solid;
+				border-width: 1px;
+				overflow: hidden;
+				word-break: normal;
+				border-color: black;
+			}
+			.tg .tg-baqh {
+				width: 15%;
+				text-align: center;
+				vertical-align: center;
+			}
+			.tg .tg-0lax {
+				width: 70%;
+				text-align: left;
+				vertical-align: center;
+			}
+			@media screen and (max-width: 767px) {
+				.tg {
+					width: auto !important;
+				}
+				.tg col {
+					width: auto !important;
+				}
+				.tg-wrap {
+					overflow-x: auto;
+					-webkit-overflow-scrolling: touch;
+					margin: auto 0px;
+				}
+			}
 		</style>
 	</head>
 	<body>
@@ -81,6 +126,66 @@
 				In the case that a reviewer asks for changes, you should respond either acknowledging that you will make those changes or making an argument against the requested changes.
 				If your patches need to be revised, please use <tt>git rebase -i</tt> to do that, then force-push, then update the description of the Pull Request by adding a summary of the changes you made, and then issue another <tt>/submit</tt>.
 			</p>
+		</div>
+
+		<h2>Should I use GitGitGadget on GitGitGadget's Git fork or on Git's GitHub mirror?</h2>
+		<div class="block">
+			<p>
+				GitGitGadget works on both GitGitGadget's Git fork (<a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a>) and Git's GitHub mirror (<a href="https://github.com/gitgitgadget/git">https://github.com/git/git</a>).
+				However, some functionality is only available when opening a PR on GitGitGadget's Git fork.
+			</p>
+			<div class="tg-wrap"><table class="tg">
+				<tr>
+					<th class="tg-0lax">Features</th>
+					<th class="tg-baqh"><a href="https://github.com/gitgitgadget/git">gitgitgadget/git</a></th>
+					<th class="tg-baqh"><a href="https://github.com/git/git">git/git</a></th>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Mirror emails answers as PR comments</td>
+					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✅</td>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Mirror PR comments as emails to the list</td>
+					<td class="tg-baqh">❌</td>
+					<td class="tg-baqh">❌</td>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Build Git and run the test suite on Linux, macOS, Windows and FreeBSD</td>
+					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✅</td>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Comment on the PR when a topic branch is created in the <a href="https://github.com/gitster/git/branches">maintainer's fork</a></td>
+					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✅</td>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Comment on the PR when the series is integrated into <tt>pu</tt>, <tt>next</tt>, <tt>master</tt> and <tt>maint</tt></td>
+					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✅</td>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Add a label to the PR when the series is integrated into <tt>pu</tt>, <tt>next</tt>, <tt>master</tt> and <tt>maint</tt></td>
+					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✅</td>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Target <tt>pu</tt>, <tt>next</tt>, <tt>master</tt> and <tt>maint</tt></td>
+					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✅</td>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Target any topic branch in the maintainer's fork, as well as <tt>git-gui/master</tt></td>
+					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">❌</td>
+				</tr>
+				<tr>
+					<td class="tg-0lax">Get a direct link between the last commit of the series and the corresponding commit in the "most upstream" integration branch as a GitHub check</td>
+					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">❌</td>
+				</tr>
+			</table></div>
 		</div>
 
 		<h2>But... what <i>is</i> GitGitGadget?</h2>

--- a/index.html
+++ b/index.html
@@ -141,47 +141,47 @@
 					<th class="tg-baqh"><a href="https://github.com/git/git">git/git</a></th>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Mirror emails answers as PR comments</td>
+					<td class="tg-0lax">Mirrors emails answers as PR comments</td>
 					<td class="tg-baqh">✓</td>
 					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Mirror PR comments as emails to the list</td>
+					<td class="tg-0lax">Mirrors PR comments as emails to the list</td>
 					<td class="tg-baqh">✗</td>
 					<td class="tg-baqh">✗</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Build Git and run the test suite on Linux, macOS, Windows and FreeBSD</td>
+					<td class="tg-0lax">Builds Git and runs the test suite on Linux, macOS, Windows and FreeBSD</td>
 					<td class="tg-baqh">✓</td>
 					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Comment on the PR when a topic branch is created in the <a href="https://github.com/gitster/git/branches">maintainer's fork</a></td>
+					<td class="tg-0lax">Comments on the PR when a topic branch is created in the <a href="https://github.com/gitster/git/branches">maintainer's fork</a></td>
 					<td class="tg-baqh">✓</td>
 					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Comment on the PR when the series is integrated into <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
+					<td class="tg-0lax">Comments on the PR when the series is integrated into <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
 					<td class="tg-baqh">✓</td>
 					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Add a label to the PR when the series is integrated into <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
+					<td class="tg-0lax">Adds a label to the PR when the series is integrated into <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
 					<td class="tg-baqh">✓</td>
 					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Target <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
+					<td class="tg-0lax">PRs can target <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
 					<td class="tg-baqh">✓</td>
 					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Target any topic branch in the maintainer's fork, as well as <code>git-gui/master</code></td>
+					<td class="tg-0lax">PRs can target any topic branch in the maintainer's fork, as well as <a href="https://github.com/prati0100/git-gui"><code>git-gui/master</code></a></td>
 					<td class="tg-baqh">✓</td>
 					<td class="tg-baqh">✗</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Get a direct link between the last commit of the series and the corresponding commit in the "most upstream" integration branch as a GitHub check</td>
+					<td class="tg-0lax">Creates a direct link between the last commit of the series and the corresponding commit in the "most upstream" integration branch as a GitHub check</td>
 					<td class="tg-baqh">✓</td>
 					<td class="tg-baqh">✗</td>
 				</tr>

--- a/index.html
+++ b/index.html
@@ -108,11 +108,11 @@
 				You might also want to read the <a href="https://git-scm.com/docs/gitworkflows">gitworkflows</a> manual page to understand how your contributions will be integrated in Git's repository, as well as <a href="https://github.com/git/git/blob/todo/MaintNotes">this note from Git's maintainer</a>.
 			</p><p>
 				The first time you use GitGitGadget, you need to be added to the list of users with permission to use GitGitGadget (this is a <i>very</i> simple anti-spam measure).
-				Any user who is already on that list can do that, by adding a comment to that Pull Request that says <tt>/allow &lt;username&gt;</name></tt> (with your GitHub login name).
+				Any user who is already on that list can do that, by adding a comment to that Pull Request that says <code>/allow &lt;username&gt;</name></code> (with your GitHub login name).
 			</p><p>
 				The Pull Request will trigger a few Checks, most importantly one that will build Git and run the test suite on the main platforms, to make sure that everything works as advertised. 
 			</p><p>
-				Once everything is ready to go, add a comment to that Pull Request saying <tt>/submit</tt>.
+				Once everything is ready to go, add a comment to that Pull Request saying <code>/submit</code>.
 				This will trigger GitGitGadget (you can see the progress via the Check called "GitGitGadget PR Handler"): it will wrap your Pull Request into a nice bundle of mails in the format expected on the Git mailing list.
 			</p>
 		</div>
@@ -124,7 +124,7 @@
 				The Git developer community is globally distributed, so please wait a day or two for reviewer comments to trickle in before sending another iteration of your patch series (if needed).
 			</p><p>
 				In the case that a reviewer asks for changes, you should respond either acknowledging that you will make those changes or making an argument against the requested changes.
-				If your patches need to be revised, please use <tt>git rebase -i</tt> to do that, then force-push, then update the description of the Pull Request by adding a summary of the changes you made, and then issue another <tt>/submit</tt>.
+				If your patches need to be revised, please use <code>git rebase -i</code> to do that, then force-push, then update the description of the Pull Request by adding a summary of the changes you made, and then issue another <code>/submit</code>.
 			</p>
 		</div>
 
@@ -161,22 +161,22 @@
 					<td class="tg-baqh">✅</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Comment on the PR when the series is integrated into <tt>pu</tt>, <tt>next</tt>, <tt>master</tt> and <tt>maint</tt></td>
+					<td class="tg-0lax">Comment on the PR when the series is integrated into <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
 					<td class="tg-baqh">✅</td>
 					<td class="tg-baqh">✅</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Add a label to the PR when the series is integrated into <tt>pu</tt>, <tt>next</tt>, <tt>master</tt> and <tt>maint</tt></td>
+					<td class="tg-0lax">Add a label to the PR when the series is integrated into <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
 					<td class="tg-baqh">✅</td>
 					<td class="tg-baqh">✅</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Target <tt>pu</tt>, <tt>next</tt>, <tt>master</tt> and <tt>maint</tt></td>
+					<td class="tg-0lax">Target <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
 					<td class="tg-baqh">✅</td>
 					<td class="tg-baqh">✅</td>
 				</tr>
 				<tr>
-					<td class="tg-0lax">Target any topic branch in the maintainer's fork, as well as <tt>git-gui/master</tt></td>
+					<td class="tg-0lax">Target any topic branch in the maintainer's fork, as well as <code>git-gui/master</code></td>
 					<td class="tg-baqh">✅</td>
 					<td class="tg-baqh">❌</td>
 				</tr>

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 				So you cloned <a href="https://github.com/git/git">https://github.com/git/git</a> and implemented a bug fix or a new feature?
 				And you already pushed it to your own fork?
 				Good, now is the time to direct your web browser to <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> (or to <a href="https://github.com/gitgitgadget/git">https://github.com/git/git</a> ) and to open a Pull Request.
-				Please make sure to use a descriptive Pull Request title and description; GitGitGadget will use these as the cover letter.
+				Please make sure to use a descriptive Pull Request title and description; GitGitGadget will use these as the subject and body of the cover letter (check out the <a href="https://git-scm.com/docs/MyFirstContribution">MyFirstContribution</a> tutorial if you are not familiar with this terminology).
 				You can CC potential reviewers by adding a footer to the PR description with the following syntax:
 				<pre>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</pre>
 			</p><p>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,8 @@
 				You can CC potential reviewers by adding a footer to the PR description with the following syntax:
 				<pre>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</pre>
 			</p><p>
-				You will also want to read <a href="https://git-scm.com/docs/SubmittingPatches">Git's guidelines</a> to make sure that your contributions are in the expected form.
+				You will also want to read <a href="https://git-scm.com/docs/SubmittingPatches">Git's contribution guidelines</a> to make sure that your contributions are in the expected form, as well as the project's <a href="https://github.com/git/git/blob/master/Documentation/CodingGuidelines">coding guidelines</a>.
+				You might also want to read the <a href="https://git-scm.com/docs/gitworkflows">gitworkflows</a> manual page to understand how your contributions will be integrated in Git's repository, as well as <a href="https://github.com/git/git/blob/todo/MaintNotes">this note from Git's maintainer</a>.
 			</p><p>
 				The first time you use GitGitGadget, you need to be added to the list of users with permission to use GitGitGadget (this is a <i>very</i> simple anti-spam measure).
 				Any user who is already on that list can do that, by adding a comment to that Pull Request that says <tt>/allow &lt;username&gt;</name></tt> (with your GitHub login name).

--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@
 				And you already pushed it to your own fork?
 				Good, now is the time to direct your web browser to <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> (or to <a href="https://github.com/gitgitgadget/git">https://github.com/git/git</a> ) and to open a Pull Request.
 				Please make sure to use a descriptive Pull Request title and description; GitGitGadget will use these as the cover letter.
+				You can CC potential reviewers by adding a footer to the PR description with the following syntax:
+				<pre>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</pre>
+			</p><p>
 				You will also want to read <a href="https://git-scm.com/docs/SubmittingPatches">Git's guidelines</a> to make sure that your contributions are in the expected form.
 			</p><p>
 				The first time you use GitGitGadget, you need to be added to the list of users with permission to use GitGitGadget (this is a <i>very</i> simple anti-spam measure).

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 				Apart from lacking the convenience of a web interface, this process also puts considerable demands on the code contributions: the mails are expected to be plain text only (no HTML!), for example, and the diffs embedded in the mails must apply cleanly (no whitespace changes!), among other things.
 			</p><p>
 				A few tutorials out there try to help with this process (e.g. <a href="https://github.com/git-for-windows/git/blob/master/CONTRIBUTING.md">Git for Windows' detailed instructions how to contribute patches to the Git project</a>, or Git's <a href="https://git-scm.com/docs/MyFirstContribution">MyFirstContribution tutorial</a>).
-				GitGitGadget tries a different approach: allow contributing patches to the Git project itself by opening a Pull Request at <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> and let GitGitGadget prepare and send the corresponding mails.
+				GitGitGadget tries a different approach: allow contributing patches to the Git project itself by opening a Pull Request either at <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> or directly at <a href="https://github.com/gitgitgadget/git">https://github.com/git/git</a> and let GitGitGadget prepare and send the corresponding mails.
 			</p>
 		</div>
 		
@@ -54,7 +54,7 @@
 			<p>
 				So you cloned <a href="https://github.com/git/git">https://github.com/git/git</a> and implemented a bug fix or a new feature?
 				And you already pushed it to your own fork?
-				Good, now is the time to direct your web browser to <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> and to open a Pull Request.
+				Good, now is the time to direct your web browser to <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> (or to <a href="https://github.com/gitgitgadget/git">https://github.com/git/git</a> ) and to open a Pull Request.
 				Please make sure to use a descriptive Pull Request title and description; GitGitGadget will use these as the cover letter.
 				You will also want to read <a href="https://git-scm.com/docs/SubmittingPatches">Git's guidelines</a> to make sure that your contributions are in the expected form.
 			</p><p>

--- a/index.html
+++ b/index.html
@@ -142,48 +142,48 @@
 				</tr>
 				<tr>
 					<td class="tg-0lax">Mirror emails answers as PR comments</td>
-					<td class="tg-baqh">✅</td>
-					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✓</td>
+					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
 					<td class="tg-0lax">Mirror PR comments as emails to the list</td>
-					<td class="tg-baqh">❌</td>
-					<td class="tg-baqh">❌</td>
+					<td class="tg-baqh">✗</td>
+					<td class="tg-baqh">✗</td>
 				</tr>
 				<tr>
 					<td class="tg-0lax">Build Git and run the test suite on Linux, macOS, Windows and FreeBSD</td>
-					<td class="tg-baqh">✅</td>
-					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✓</td>
+					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
 					<td class="tg-0lax">Comment on the PR when a topic branch is created in the <a href="https://github.com/gitster/git/branches">maintainer's fork</a></td>
-					<td class="tg-baqh">✅</td>
-					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✓</td>
+					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
 					<td class="tg-0lax">Comment on the PR when the series is integrated into <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
-					<td class="tg-baqh">✅</td>
-					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✓</td>
+					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
 					<td class="tg-0lax">Add a label to the PR when the series is integrated into <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
-					<td class="tg-baqh">✅</td>
-					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✓</td>
+					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
 					<td class="tg-0lax">Target <code>pu</code>, <code>next</code>, <code>master</code> and <code>maint</code></td>
-					<td class="tg-baqh">✅</td>
-					<td class="tg-baqh">✅</td>
+					<td class="tg-baqh">✓</td>
+					<td class="tg-baqh">✓</td>
 				</tr>
 				<tr>
 					<td class="tg-0lax">Target any topic branch in the maintainer's fork, as well as <code>git-gui/master</code></td>
-					<td class="tg-baqh">✅</td>
-					<td class="tg-baqh">❌</td>
+					<td class="tg-baqh">✓</td>
+					<td class="tg-baqh">✗</td>
 				</tr>
 				<tr>
 					<td class="tg-0lax">Get a direct link between the last commit of the series and the corresponding commit in the "most upstream" integration branch as a GitHub check</td>
-					<td class="tg-baqh">✅</td>
-					<td class="tg-baqh">❌</td>
+					<td class="tg-baqh">✓</td>
+					<td class="tg-baqh">✗</td>
 				</tr>
 			</table></div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 			</p><p>
 				Apart from lacking the convenience of a web interface, this process also puts considerable demands on the code contributions: the mails are expected to be plain text only (no HTML!), for example, and the diffs embedded in the mails must apply cleanly (no whitespace changes!), among other things.
 			</p><p>
-				A few tutorials out there try to help with this process (e.g. <a href="https://github.com/git-for-windows/git/blob/master/CONTRIBUTING.md">Git for Windows' detailed instructions how to contribute patches to the Git project</a>).
+				A few tutorials out there try to help with this process (e.g. <a href="https://github.com/git-for-windows/git/blob/master/CONTRIBUTING.md">Git for Windows' detailed instructions how to contribute patches to the Git project</a>, or Git's <a href="https://git-scm.com/docs/MyFirstContribution">MyFirstContribution tutorial</a>).
 				GitGitGadget tries a different approach: allow contributing patches to the Git project itself by opening a Pull Request at <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> and let GitGitGadget prepare and send the corresponding mails.
 			</p>
 		</div>


### PR DESCRIPTION
As discussed in https://github.com/gitgitgadget/gitgitgadget/issues/146, here is a small update to the GGG homepage to mention that it can also be used on github.com/git/git.

This PR also adds the following to the homepage:
- Add a couple of links to other resources
- Mention the CC syntax
- Add a section mentioning GGG's features and which work on GGG's git fork vs github.com/git/git

@dscho @webstech

Note: the table and its CSS was generated using an online HTML table generator, which I tried to clean up a bit. Also if we'd rather not use emoji in the table we could use "yes"/"no".

Don't hesitate if you think of other features that should be mentioned or that are not available on github.com/git/git.