### PR TITLE
Instruct readers to drop PR description for single commit PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 .gitattributes eol=lf
-*.html eol=lf
+*.html eol=lf diff=html
 *.svg eol=lf
 *.png binary

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 				Good, now is the time to direct your web browser to <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> (or to <a href="https://github.com/git/git">https://github.com/git/git</a> ) and to open a Pull Request.
 				A few things to note about a GitGitGadget Pull Request:
 				<ul>
-					<li>Please make sure to use a descriptive title and description; GitGitGadget will use these as the subject and body of the cover letter (check out the <a href="https://git-scm.com/docs/MyFirstContribution">MyFirstContribution</a> tutorial if you are not familiar with this terminology).</li>
+					<li>Please make sure to use a descriptive title and description; GitGitGadget will use these as the subject and body of the cover letter (check out the <a href="https://git-scm.com/docs/MyFirstContribution#cover-letter">MyFirstContribution</a> tutorial if you are not familiar with this terminology).</li>
 					<li>You can CC potential reviewers by adding a footer to the PR description with the following syntax:</br>
 					<code>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</code>
 					</li>

--- a/index.html
+++ b/index.html
@@ -100,10 +100,13 @@
 				So you cloned <a href="https://github.com/git/git">https://github.com/git/git</a> and implemented a bug fix or a new feature?
 				And you already pushed it to your own fork?
 				Good, now is the time to direct your web browser to <a href="https://github.com/gitgitgadget/git">https://github.com/gitgitgadget/git</a> (or to <a href="https://github.com/git/git">https://github.com/git/git</a> ) and to open a Pull Request.
-				Please make sure to use a descriptive Pull Request title and description; GitGitGadget will use these as the subject and body of the cover letter (check out the <a href="https://git-scm.com/docs/MyFirstContribution">MyFirstContribution</a> tutorial if you are not familiar with this terminology).
-				You can CC potential reviewers by adding a footer to the PR description with the following syntax:
-			</p><p>
-				<code>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</code>
+				A few things to note about a GitGitGadget Pull Request:
+				<ul>
+					<li>Please make sure to use a descriptive title and description; GitGitGadget will use these as the subject and body of the cover letter (check out the <a href="https://git-scm.com/docs/MyFirstContribution">MyFirstContribution</a> tutorial if you are not familiar with this terminology).</li>
+					<li>You can CC potential reviewers by adding a footer to the PR description with the following syntax:</br>
+					<code>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</code>
+					</li>
+				</ul>
 			</p><p>
 				You will also want to read <a href="https://git-scm.com/docs/SubmittingPatches">Git's contribution guidelines</a> to make sure that your contributions are in the expected form, as well as the project's <a href="https://github.com/git/git/blob/master/Documentation/CodingGuidelines">coding guidelines</a>.
 				You might also want to read the <a href="https://git-scm.com/docs/gitworkflows">gitworkflows</a> manual page to understand how your contributions will be integrated in Git's repository, as well as <a href="https://github.com/git/git/blob/todo/MaintNotes">this note from Git's maintainer</a>.

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
 				A few things to note about a GitGitGadget Pull Request:
 				<ul>
 					<li>Please make sure to use a descriptive title and description; GitGitGadget will use these as the subject and body of the cover letter (check out the <a href="https://git-scm.com/docs/MyFirstContribution#cover-letter">MyFirstContribution</a> tutorial if you are not familiar with this terminology).</li>
+					<li>If your pull request consist of a single commit, leave the pull request description empty, as your commit message itself should be enough to explain the rationale for your changes.</li>
 					<li>You can CC potential reviewers by adding a footer to the PR description with the following syntax:</br>
 					<code>CC: Revi Ewer &lt;revi.ewer@some.domain&gt;, Ill Takalook &lt;ill.takalook@other.domain&gt;</code>
 					</li>


### PR DESCRIPTION
For single commit PRs, GitHub prepends the commit message to the PR
description, before the PR template.

Contributors will then (hopefully) remove the template and keep the rest
of the description. Since the PR description is added as an in-patch
commentary for single-commit PRs, the same text appears twice in the
generatred email (once in the commit messge and once in the in-patch
commentary), decreasing the signal-to-noise ratio for reviewers.

Let's instruct readers to empty the PR description for single commit
PRs. 

Additionnally, mark HTML files as such for diff-related purposes (patch 1/4).

This partly addresses:
https://github.com/gitgitgadget/gitgitgadget/issues/340