### PR TITLE
Add `/preview` instruction into the `/submit' sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
 				The Pull Request will trigger a few Checks, most importantly one that will build Git and run the test suite on the main platforms, to make sure that everything works as advertised.
 			</p><p>
 				Once you feel everything is ready to go, add a comment to that Pull Request saying <code>/preview</code>. This will send you a copy of the Pull Request to check.
-				If you are happy, add a comment to that Pull Request saying <code>/submit</code>.
+				Once you are happy with the result, add a comment to that Pull Request saying <code>/submit</code>.
 				This will trigger GitGitGadget (you can see the progress via the Check called "GitGitGadget PR Handler"): it will wrap your Pull Request into a nice bundle of mails in the format expected on the Git mailing list.
 			</p>
 		</div>

--- a/index.html
+++ b/index.html
@@ -117,7 +117,8 @@
 			</p><p>
 				The Pull Request will trigger a few Checks, most importantly one that will build Git and run the test suite on the main platforms, to make sure that everything works as advertised.
 			</p><p>
-				Once everything is ready to go, add a comment to that Pull Request saying <code>/submit</code>.
+				Once you feel everything is ready to go, add a comment to that Pull Request saying <code>/preview</code>. This will send you a copy of the Pull Request to check.
+				If you are happy, add a comment to that Pull Request saying <code>/submit</code>.
 				This will trigger GitGitGadget (you can see the progress via the Check called "GitGitGadget PR Handler"): it will wrap your Pull Request into a nice bundle of mails in the format expected on the Git mailing list.
 			</p>
 		</div>


### PR DESCRIPTION
Users may not know that they can preview how their PR will look when submitted to the Git List. Tell them about the GGG action that provides that preview. ---
Apologies for any 'monkey patching' errors.