### PR TITLE
Clarify how to be added to allow list

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,8 @@
 				You might also want to read the <a href="https://git-scm.com/docs/gitworkflows">gitworkflows</a> manual page to understand how your contributions will be integrated in Git's repository, as well as <a href="https://github.com/git/git/blob/todo/MaintNotes">this note from Git's maintainer</a>.
 			</p><p>
 				The first time you use GitGitGadget, you need to be added to the list of users with permission to use GitGitGadget (this is a <i>very</i> simple anti-spam measure).
-				Any user who is already on that list can do that, by adding a comment to that Pull Request that says <code>/allow &lt;username&gt;</code> (with your GitHub login name).
+				Using <a src="https://web.libera.chat/#git-devel">IRC</a> or <a src="https://github.com/gitgitgadget/git/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+%22%2Fallow%22">PRs</a> you can find a user already on this list and request them to add you to the list.
+				To do so, they simply have to add a comment to that Pull Request that says <code>/allow</name></code>.
 			</p><p>
 				The Pull Request will trigger a few Checks, most importantly one that will build Git and run the test suite on the main platforms, to make sure that everything works as advertised.
 			</p><p>


### PR DESCRIPTION
On first reading, I found very confusing to understand how I could be added to allow list. I just tried creating the PR anyway and discovered that the first message by your bot explains how to add someone. I believe that it would improve first user interaction if they already knew how to find this user that may allow them. (Even better would be to have it automated, but that's a more complex task I don't dare to try to work on)

Clone of #14, applying required correction. And this time I figured out what I got wrong which caused it to be closed. Very sorry for the noise