### PR TITLE
Don't specify the password on the command line

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,7 +20,7 @@ jobs:
           git add -A \*.html &&
           git diff-index --cached --exit-code HEAD -- ||
           echo "need-to-commit=yes" >>$GITHUB_OUTPUT
-      - name: commit & push
+      - name: commit
         if: steps.check.outputs.need-to-commit == 'yes'
         run: |
           git config user.name "${{github.actor}}" &&
@@ -28,5 +29,21 @@ jobs:
           git update-index --refresh &&
           git diff-files --exit-code &&
           git diff-index --cached --exit-code HEAD -- &&
-          git push
-
+          git bundle create git.bundle ${{ github.event.pull_request.head.sha }}..${{ github.event.pull_request.head.ref }}
+      - name: commit
+        if: steps.check.outputs.need-to-commit == 'yes' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        run: git push
+      - name: publish bundle
+        id: bundle
+        if: steps.check.outputs.need-to-commit == 'yes' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle
+          path: git.bundle
+      - name: instructions how to fetch bundle
+        if: steps.check.outputs.need-to-commit == 'yes' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+        run: |
+          body='The HTML pages are out of date. Please download the `bundle` artifact from ${{ steps.bundle.outputs.artifact-url }}, extract the `git.bundle` file from it, then run `git pull /path/to/git.bundle ${{ github.event.pull_request.head.ref }}` and then push to the PR branch'
+          echo "::error::$body" >&2
+          echo "$body" >>$GITHUB_STEP_SUMMARY
+          exit 1

--- a/reply-to-this.html
+++ b/reply-to-this.html
@@ -33,7 +33,7 @@
 <p>Simply copy the file to the <code>new</code> subfolder in your mailer&#39;s maildir folder.</p>
 <h3 id="if-you-use-webmail-gmail-and-friends">If you use webmail (GMail and friends)</h3>
 <p>You can use the command-line tool <code>curl</code> (provided that your version has IMAP support):</p>
-<pre><code class="language-sh">curl -g --user &quot;&lt;email&gt;:&lt;password&gt;&quot; --url &quot;imaps://imap.gmail.com/INBOX&quot; -T /path/to/raw.txt
+<pre><code class="language-sh">curl -g --user &quot;&lt;email&gt;&quot; --url &quot;imaps://imap.gmail.com/INBOX&quot; -T /path/to/raw.txt
 </code></pre>
 
     </div>

--- a/reply-to-this.md
+++ b/reply-to-this.md
@@ -15,5 +15,5 @@ Simply copy the file to the `new` subfolder in your mailer's maildir folder.
 You can use the command-line tool `curl` (provided that your version has IMAP support):
 
 ```sh
-curl -g --user "<email>:<password>" --url "imaps://imap.gmail.com/INBOX" -T /path/to/raw.txt
+curl -g --user "<email>" --url "imaps://imap.gmail.com/INBOX" -T /path/to/raw.txt
 ```


### PR DESCRIPTION
https://www.netmeister.org/blog/passing-passwords.html has a decent overview of the security issues with that.

Since this is interactive, getting curl to prompt for the password is probably the easiest alternative. From
https://curl.se/docs/manpage.html#-u

> If you simply specify the username, curl prompts for a password.

I don't have an easy way to test the actual command in this doc, but the flag does seem to behave as documented at least:

```
$ curl --user user@example.com https://google.com
Enter host password for user 'user@example.com'
```

Fixes gitgitgadget/gitgitgadget#1843