### PR TITLE
Update git-gui references

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -60,7 +60,7 @@ GitGitGadget works on both GitGitGadget's Git fork ([https://github.com/gitgitga
 | Comments on the PR when the series is integrated into `seen`, `next`, `master` and `maint` | ✓ | ✓
 | Adds a label to the PR when the series is integrated into `seen`, `next`, `master` and `maint` | ✓ | ✓
 | PRs can target `seen`, `next`, `master` and `maint` | ✓ | ✓
-| PRs can target any topic branch in the maintainer's fork, as well as [`git-gui/master`](https://github.com/prati0100/git-gui) | ✓ | ✗
+| PRs can target any topic branch in the maintainer's fork, as well as [`git-gui/master`](https://github.com/j6t/git-gui) | ✓ | ✗
 | Creates a direct link between the last commit of the series and the corresponding commit in the "most upstream" integration branch as a GitHub check | ✓ | ✗
 
 </div>

--- a/content/architecture.md
+++ b/content/architecture.md
@@ -151,4 +151,4 @@ The two pipelines are identical except for these aspects:
 
 ### Git GUI's branches
 
-As GitGitGadget can also be used to contribute Git GUI patches and patch series, there is also the [Synchronize git-gui.git (branches only) to GitGitGadget](https://dev.azure.com/gitgitgadget/git/_build?definitionId=10) pipeline. It mirrors the branches of Pratyush Yadav's repository (i.e. the current Git GUI maintainer's authoritative repository) into the `git-gui/*` namespace on `gitgitgadget/git`.
+As GitGitGadget can also be used to contribute Git GUI patches and patch series, there is also the [Synchronize git-gui.git (branches only) to GitGitGadget](https://dev.azure.com/gitgitgadget/git/_build?definitionId=10) pipeline. It mirrors the branches of Pratyush Yadav's repository (i.e. the former Git GUI maintainer's authoritative repository) into the `git-gui/*` namespace on `gitgitgadget/git`.


### PR DESCRIPTION
Ideally though, the Azure pipeline mentioned in `archiecture.md` could be reconfigured to point to the new repository and re-enabled, if it is still needed.

FWIW the current HEAD of git-gui/master seems to be in sync already.