### PR TITLE
Make site mobile responsive

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -14,13 +14,13 @@ body {
   padding-bottom: .1em;
   border-radius: 2em;
 }
+img {
+  max-width: 100%;
+  height: auto;
+}
 .banner {
   text-align: center;
   font-weight: bold;
-  img {
-    max-width: 100%;
-    height: auto;
-  }
 }
 big {
   font-size: 400%;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -27,6 +27,22 @@ big {
 small {
   font-size: 70%;
 }
+pre {
+  background-color: rgb(247, 243, 239);
+  border: 1px solid #c5bbb0;
+  border-radius: 0.5em;
+  padding: 1em;
+  overflow-x: auto;
+}
+code {
+  background-color: rgb(247, 243, 239);
+  padding: 0.1em 0.3em;
+  border-radius: 0.25em;
+}
+pre code {
+  background-color: transparent;
+  padding: 0;
+}
 div.feature-matrix {
   table {
     border-collapse: collapse;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -16,8 +16,9 @@ body {
 .banner {
   text-align: center;
   font-weight: bold;
-  td img {
-    height: 150px;
+  img {
+    max-width: 100%;
+    height: auto;
   }
 }
 big {

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -79,6 +79,10 @@ div.feature-matrix {
   }
 }
 @media screen and (max-width: 767px) {
+  body {
+    margin-right: 3%;
+    margin-left: 3%;
+  }
   .tg {
     width: auto !important;
   }

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -78,6 +78,11 @@ div.feature-matrix {
     vertical-align: center;
   }
 }
+@media screen and (max-width: 450px) {
+  big {
+    font-size: 300%;
+  }
+}
 @media screen and (max-width: 767px) {
   body {
     margin-right: 3%;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -4,6 +4,7 @@ body {
   background-image: linear-gradient(#d7cdc0ff, #fdf7f6ff);
   margin-right: 10%;
   margin-left: 10%;
+  overflow-wrap: break-word;
 }
 .block {
   background-color: rgb(247, 243, 239);

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ .Title }}</title>
     {{- $style := resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "main.scss" . | css.Sass }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -7,21 +7,6 @@ Contributing git.git patches via GitHub PRs<br />
 <small>... one iteration at a time... </small>
 {{- end -}}
 <div class="banner">
-  {{- if eq .Kind "home" }}
   {{ partial "logo.html" . }}
   {{ partial "subtitle.html" . }}
-  {{- else }}
-  <table style="width: 100%">
-    <tbody>
-      <tr>
-        <td>
-	{{ partial "logo.html" . }}
-        </td>
-        <td>
-        {{ partial "subtitle.html" . }}
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  {{- end }}
 </div>{{ if eq .Kind "home" }}<hr />{{ end }}


### PR DESCRIPTION
## Summary

This PR closes #19 and makes the site (all 3 pages) mobile responsive without changing the intended UI on desktop, except for the non-homepage table banner which has been removed to remain stylistically consistent with the homepage banner, responsive and more maintainable. No content has been edited.

A live demo can be tested here [https://gitgitgadget.ritovision.com](https://gitgitgadget.ritovision.com)

## What has changed

- Viewport tag added
- The header table is replaced with a responsive block display
- non-homepage pages no longer use the table banner, instead sharing the homepage banner structure
- Left and right margin spacing reduced on mobile breakpoint
- Banner title decreased on small ≤450 screen sizes to fit without overflow behaviors
- Horizontal broken page scrolling caused by content not fitting on small screens is resolved by:
   - making image sizes responsive
   - making code blocks use overflow scroll
   - making long text strings break apart and wrap down to the next line as needed
   
<details><summary><strong>Before and After Screenshots</strong></summary>
<br /><br />

**Homepage - BEFORE**
<img width="340" alt="homepage-before" src="https://github.com/user-attachments/assets/10420fa1-34ae-4544-abcf-203791b7028b" />

<br /><br />


**Homepage - AFTER**
<img width="340" alt="homepage-after" src="https://github.com/user-attachments/assets/64f90c4a-561e-472a-b1d5-cdcf4666af16" />

<br /><br />


**Architecture - BEFORE**
<img width="340" alt="architecture-before" src="https://github.com/user-attachments/assets/b7b167d8-3c90-484c-bd5a-fae0a479cbc1" />

<br /><br />


**Architecture - AFTER**

<img width="340" alt="architecture-after" src="https://github.com/user-attachments/assets/466da586-2ec9-499b-9f50-afbb538e74c4" />

<br /><br />


**Reply-to-this - BEFORE**
<img width="340" alt="reply-to-this-before" src="https://github.com/user-attachments/assets/87008963-5a2e-4da6-afc4-f4ea07bf46c4" />

<br /><br />


**Reply-to-this - AFTER**

<img width="340" alt="reply-to-this-after" src="https://github.com/user-attachments/assets/01ee2946-c1cd-4c39-9493-de1c1af2d275" />


<br /><br />

---

**Desktop Homepage - BEFORE**
<img width="1920" alt="home-desktop-before" src="https://github.com/user-attachments/assets/e0c1c6f6-19c6-407b-bb25-1ec864f9b7e8" />

<br /><br />

**Desktop Homepage - AFTER**

*Notice the layout still looks and scales the same*

<img width="1920" alt="home-desktop-after" src="https://github.com/user-attachments/assets/f2eabd4e-ff17-4738-a299-cb51d018dc04" />

<br /><br />

</details>


