### PR TITLE
add canonical link tags for all pages

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ .Title }}</title>
+    {{- $canonical := .Permalink | replaceRE "\\.html$" "" -}}
+    <link rel="canonical" href="{{ $canonical }}">
     <link rel="icon" href="{{ relURL "favicon.ico" }}">
     {{- $style := resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "main.scss" . | css.Sass }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">


### PR DESCRIPTION
Add canonical link tags in the base template.

Use .Permalink as the source and strip a trailing .html suffix so canonical URLs are extensionless (e.g. /architecture).

Prefer extensionless canonical URLs because they are shorter and cleaner, while the .html variants remain valid and accessible on GitHub Pages.

Canonical tags tell search engines which URL is authoritative, reducing duplicate-URL ambiguity for indexing and ranking.