### PR TITLE
footer: remove trailing slashes to prevent 404s

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,8 +3,8 @@
   <nav>
     <ul>
       <li><a href="{{ relURL "/" }}">Home</a></li>
-      <li><a href="{{ relURL "architecture/" }}">Architecture</a></li>
-      <li><a href="{{ relURL "reply-to-this/" }}">Reply to this</a></li>
+      <li><a href="{{ relURL "/architecture" }}">Architecture</a></li>
+      <li><a href="{{ relURL "/reply-to-this" }}">Reply to this</a></li>
     </ul>
   </nav>
   <a class="footer-home-link" href="{{ relURL "/" }}" aria-label="Home">


### PR DESCRIPTION
I found an edge case: on GitHub Pages, with `uglyURLs` enabled, extensionless paths with trailing slashes return `404`.

Footer links currently include trailing slashes, so they are 404ing.

This change removes trailing slashes from footer links so they resolve correctly.

Path behavior:
/architecture.html = ✅
/architecture = ✅
/architecture/ = ❌